### PR TITLE
Wrap Proj's geodesics library

### DIFF
--- a/src/Proj.jl
+++ b/src/Proj.jl
@@ -91,6 +91,7 @@ const GEODESIC_VERSION_NUM = VersionNumber
 include("libproj.jl")
 include("crs.jl")
 include("coord.jl")
+include("geod.jl")
 include("error.jl")
 
 """

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -78,3 +78,30 @@ Returns `(lat, lon, azimuth)` at the `relative_arclength` between the line's sta
 function geod_position_relative(line::geod_geodesicline, relative_arclength::Real)
     return geod_position(line, line.s13 * relative_arclength)
 end
+
+"""
+    geod_path(geodesic::geod_geodesic, lat1, lon1, lat2, lon2, npoints = 1000)
+
+Returns a tuple of vectors representing longitude and latitude.
+
+## Example
+
+```julia
+geod = Proj.geod_geodesic(6378137, 1/298.257223563)
+lats, lons = Proj.geod_path(geod, 40.64, -73.78, 1.36, 103.99)
+```
+"""
+function geod_path(geodesic::geod_geodesic, lat1, lon1, lat2, lon2, npoints = 1000; caps = Cuint(0))
+    inverse_line = geod_inverseline(geodesic, lat1, lon1, lat2, lon2, caps)
+
+    lats = zeros(Float64, npoints)
+    lons = zeros(Float64, npoints)
+
+    for i in 1:npoints
+        lats[i], lons[i], _ = geod_position_relative(inverse_line, (i-1)/npoints)
+    end
+
+    return lats, lons
+end
+# lines(GeoMakie.coastlines(); linewidth = 0.5, axis = (; aspect = DataAspect(), title = "Geodesic path from JFK to SIN"))
+# lines!(lons, lats; linewidth = 1.5)

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -3,12 +3,20 @@
 
 # geod_geodesic
 
+"""
+    Proj._null(geod_*)
+
+A null initializer which returns an object of the given type, 
+with all floats set to NaN, and all integers set to 0.
+
+Available types are `geod_geodesic`, `geod_geodesicline`.
+"""
 function _null(::Type{geod_geodesic})
     return geod_geodesic(
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        ntuple(_ -> 0.0, Val(6)),
-        ntuple(_ -> 0.0, Val(15)),
-        ntuple(_ -> 0.0, Val(21)),
+        NaN64, NaN64, NaN64, NaN64, NaN64, NaN64, NaN64, NaN64, NaN64,
+        ntuple(_ -> NaN64, Val(6)),
+        ntuple(_ -> NaN64, Val(15)),
+        ntuple(_ -> NaN64, Val(21)),
     )
 end
 
@@ -22,8 +30,8 @@ end
 
 function _null(::Type{Proj.geod_geodesicline})
     return geod_geodesicline(
-        (0 for _ in 1:30)...,
-        ntuple(_ -> 0.0, 7), ntuple(_ -> 0.0, 7), ntuple(_ -> 0.0, 7), ntuple(_ -> 0.0, 6), ntuple(_ -> 0.0, 6),
+        (NaN64 for _ in 1:30)...,
+        ntuple(_ -> NaN64, 7), ntuple(_ -> NaN64, 7), ntuple(_ -> NaN64, 7), ntuple(_ -> NaN64, 6), ntuple(_ -> NaN64, 6),
         Cuint(0)
     )
 end
@@ -56,7 +64,7 @@ function geod_position(line::geod_geodesicline, s12::Real)
     lon = Ref{Cdouble}(NaN64)
     azi = Ref{Cdouble}(NaN64)
 
-    return geod_position(pointer_from_objref(line), s12, lat, lon, azi)
+    geod_position(pointer_from_objref(line), s12, lat, lon, azi)
 
     return lat[], lon[], azi[]
 end

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -13,10 +13,10 @@
 # Finally, in order to sample along a geodetic path, we have a convenience function `geod_path(geodesic::geod_geodesic, lat1, lon1, lat2, lon2, npoints)`.
 
 # Simple examples are available in the docstrings for each of these functions, but
-# do note that quite a few of them display the C documentation directly.  Look at 
+# do note that quite a few of them display the C documentation directly.  Look at
 # the output of e.g. `methods(geod_geodesic)` for a list of all available methods.
 
-# ## Basic wrappers 
+# ## Basic wrappers
 # These are some basic wrappers for `geod_direct` and `geod_inverse`.
 
 function geod_direct(g::geod_geodesic, lat::Real, lon::Real, azi::Real, s12::Real)
@@ -50,7 +50,7 @@ end
 """
     Proj._null(geod_*)
 
-A null initializer which returns an object of the given type, 
+A null initializer which returns an object of the given type,
 with all floats set to NaN, and all integers set to 0.
 
 Available types are `geod_geodesic`, `geod_geodesicline, `geod_polygon`.
@@ -86,7 +86,7 @@ function geod_directline(g::geod_geodesic, lat1, lon1, azi1, s12, caps::Cuint = 
     new_objref = Ref(init_obj)
     geod_directline(
         new_objref,
-        Ref(g), 
+        Ref(g),
         lat1, lon1, azi1, s12, caps
     )
     return new_objref[]
@@ -98,7 +98,7 @@ function geod_inverseline(g::geod_geodesic, lat1, lon1, lat2, lon2, caps::Cuint 
 
     geod_inverseline(
         new_objref,
-        Ref(g), 
+        Ref(g),
         lat1, lon1, lat2, lon2, caps
     )
     return new_objref[]
@@ -111,8 +111,8 @@ end
 
 
 # !!! note
-#     This returns according to the C order (y, x, az).  
-#     Do we want this to return by the Julian order (x, y, azi)?  
+#     This returns according to the C order (y, x, az).
+#     Do we want this to return by the Julian order (x, y, azi)?
 #     If so, should this be a new function?
 
 function geod_position(line::geod_geodesicline, s12::Real)
@@ -131,7 +131,7 @@ end
     geod_position(line::geod_geodesicline, s12s::AbstractArray{<: Real})::(lats, lons, azis)
 
 Returns `(lat, lon, azimuth)` at the `s12` distance along the line.
-If provided an array, will return three `similar` arrays, which also have 
+If provided an array, will return three `similar` arrays, which also have
 
 """
 function geod_position(line::geod_geodesicline, s12s::AbstractArray{<: Real})
@@ -153,7 +153,7 @@ end
 """
     geod_position_relative(line::geod_geodesicline, relative_arclength::Real)
 
-Returns `(lat, lon, azimuth)` at the `relative_arclength` between the line's start and end point.  
+Returns `(lat, lon, azimuth)` at the `relative_arclength` between the line's start and end point.
 `relative_arclength` can be any real value, but values along the line should be between 0 and 1.
 
 If `relative_arclength` is an Array, then a Tuple of arrays are returned.
@@ -252,7 +252,7 @@ function geod_polygon_compute(g::geod_geodesic, p::geod_polygon, reverse::Bool =
     # initializing to zero makes the return not happen for that value, so we need to initialize to 1
     pA = Ref{Cdouble}(1e0)
     pP = Ref{Cdouble}(1e0)
-    
+
     n = geod_polygon_compute(Ref(g), Ref(p), Cint(reverse), Cint(sign), pA, pP)
 
     return (pA[], pP[])
@@ -261,7 +261,7 @@ end
 """
     geod_polygonarea(g::geod_geodesic, lats::AbstractVector{<: Real}, lons::AbstractVector{<: Real})
 
-    Simple interface to compute the geodesic area of a polygon.  
+    Simple interface to compute the geodesic area of a polygon.
 Returns a tuple of `(area, perimeter)` in m² and m respectively.
 """
 function geod_polygonarea(g::geod_geodesic, lats::AbstractVector{<: Real}, lons::AbstractVector{<: Real})
@@ -271,7 +271,7 @@ function geod_polygonarea(g::geod_geodesic, lats::AbstractVector{<: Real}, lons:
 
     pA = Ref{Cdouble}(1e0)
     pP = Ref{Cdouble}(1e0)
-    
+
     geod_polygonarea(Ref(g), c_lats, c_lons, length(lats), pA, pP)
 
     return (pA[], pP[])

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -20,9 +20,9 @@
 # These are some basic wrappers for `geod_direct` and `geod_inverse`.
 
 function geod_direct(g::geod_geodesic, lat::Real, lon::Real, azi::Real, s12::Real)
-    lat_out = Ref{Cdouble}(NaN64)
-    lon_out = Ref{Cdouble}(NaN64)
-    azi_out = Ref{Cdouble}(NaN64)
+    lat_out = Ref{Cdouble}(NaN)
+    lon_out = Ref{Cdouble}(NaN)
+    azi_out = Ref{Cdouble}(NaN)
 
     geod_direct(Ref(g), lat, lon, azi, s12, lat_out, lon_out, azi_out)
 
@@ -30,9 +30,9 @@ function geod_direct(g::geod_geodesic, lat::Real, lon::Real, azi::Real, s12::Rea
 end
 
 function geod_inverse(g::geod_geodesic, lat1::Real, lon1::Real, lat2::Real, lon2::Real,)
-    s12 = Ref{Cdouble}(NaN64)
-    azi1 = Ref{Cdouble}(NaN64)
-    azi2 = Ref{Cdouble}(NaN64)
+    s12 = Ref{Cdouble}(NaN)
+    azi1 = Ref{Cdouble}(NaN)
+    azi2 = Ref{Cdouble}(NaN)
 
     geod_inverse(Ref(g), lat1, lat2, lon1, lon2, s12, azi1, azi2)
 
@@ -57,10 +57,10 @@ Available types are `geod_geodesic`, `geod_geodesicline, `geod_polygon`.
 """
 function _null(::Type{geod_geodesic})
     return geod_geodesic(
-        NaN64, NaN64, NaN64, NaN64, NaN64, NaN64, NaN64, NaN64, NaN64,
-        ntuple(_ -> NaN64, Val(6)),
-        ntuple(_ -> NaN64, Val(15)),
-        ntuple(_ -> NaN64, Val(21)),
+        NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN,
+        ntuple(_ -> NaN, Val(6)),
+        ntuple(_ -> NaN, Val(15)),
+        ntuple(_ -> NaN, Val(21)),
     )
 end
 
@@ -75,8 +75,8 @@ end
 
 function _null(::Type{geod_geodesicline})
     return geod_geodesicline(
-        (NaN64 for _ in 1:30)...,
-        ntuple(_ -> NaN64, 7), ntuple(_ -> NaN64, 7), ntuple(_ -> NaN64, 7), ntuple(_ -> NaN64, 6), ntuple(_ -> NaN64, 6),
+        (NaN for _ in 1:30)...,
+        ntuple(_ -> NaN, 7), ntuple(_ -> NaN, 7), ntuple(_ -> NaN, 7), ntuple(_ -> NaN, 6), ntuple(_ -> NaN, 6),
         Cuint(0)
     )
 end
@@ -116,9 +116,9 @@ end
 #     If so, should this be a new function?
 
 function geod_position(line::geod_geodesicline, s12::Real)
-    lat = Ref{Cdouble}(NaN64)
-    lon = Ref{Cdouble}(NaN64)
-    azi = Ref{Cdouble}(NaN64)
+    lat = Ref{Cdouble}(NaN)
+    lon = Ref{Cdouble}(NaN)
+    azi = Ref{Cdouble}(NaN)
 
     geod_position(Ref(line), s12, lat, lon, azi)
 
@@ -138,9 +138,9 @@ function geod_position(line::geod_geodesicline, s12s::AbstractArray{<: Real})
     result_lon = similar(s12s)
     result_lat = similar(s12s)
     result_azi = similar(s12s)
-    lat = Ref{Cdouble}(NaN64)
-    lon = Ref{Cdouble}(NaN64)
-    azi = Ref{Cdouble}(NaN64)
+    lat = Ref{Cdouble}(NaN)
+    lon = Ref{Cdouble}(NaN)
+    azi = Ref{Cdouble}(NaN)
     for ind in eachindex(s12s)
         geod_position(Ref(line), s12s[ind], lat, lon, azi)
         result_lat[ind] = lat[]
@@ -173,14 +173,14 @@ Calls the C function `geod_genposition` and returns a tuple of the results, name
 `(plat2[], plon2[], pazi2[], ps12[], pm12[], pM12[], pM21[], pS12[])`
 """
 function geod_genposition(l::geod_geodesicline, flags::Union{Cuint, geod_flags}, s12_a12)
-    plat2 = Ref{Cdouble}(NaN64)
-    plon2 = Ref{Cdouble}(NaN64)
-    pazi2 = Ref{Cdouble}(NaN64)
-    ps12 = Ref{Cdouble}(NaN64)
-    pm12 = Ref{Cdouble}(NaN64)
-    pM12 = Ref{Cdouble}(NaN64)
-    pM21 = Ref{Cdouble}(NaN64)
-    pS12 = Ref{Cdouble}(NaN64)
+    plat2 = Ref{Cdouble}(NaN)
+    plon2 = Ref{Cdouble}(NaN)
+    pazi2 = Ref{Cdouble}(NaN)
+    ps12 = Ref{Cdouble}(NaN)
+    pm12 = Ref{Cdouble}(NaN)
+    pM12 = Ref{Cdouble}(NaN)
+    pM21 = Ref{Cdouble}(NaN)
+    pS12 = Ref{Cdouble}(NaN)
 
     geod_genposition(Ref(l), flags, s12_a12, plat2, plon2, pazi2, ps12, pm12, pM12, pM21, pS12)
 
@@ -218,8 +218,8 @@ end
 
 function _null(::Type{geod_polygon})
     return geod_polygon(
-        NaN64, NaN64, NaN64, NaN64,
-        (NaN64, NaN64), (NaN64, NaN64),
+        NaN, NaN, NaN, NaN,
+        (NaN, NaN), (NaN, NaN),
         Cint(0), Cint(0), Cint(0)
     )
 end

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -143,8 +143,8 @@ function geod_position(line::geod_geodesicline, s12s::AbstractArray{<: Real})
     azi = Ref{Cdouble}(NaN64)
     for ind in eachindex(s12s)
         geod_position(Ref(line), s12s[ind], lat, lon, azi)
-        result_lon[ind] = lon[]
         result_lat[ind] = lat[]
+        result_lon[ind] = lon[]
         result_azi[ind] = azi[]
     end
     return result_lat, result_lon, result_azi
@@ -202,9 +202,11 @@ lats, lons = Proj.geod_path(geod, 40.64, -73.78, 1.36, 103.99)
 ```
 """
 function geod_path(geodesic::geod_geodesic, lat1, lon1, lat2, lon2, npoints = 1000; caps = Cuint(0))
+    @assert npoints > 1
+
     inverse_line = geod_inverseline(geodesic, lat1, lon1, lat2, lon2, caps)
 
-    lats, lons, azis = geod_position(inverse_line, LinRange(0, 1, npoints))
+    lats, lons, azis = geod_position_relative(inverse_line, LinRange(0, 1, npoints))
 
     return lats, lons
 end

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -79,6 +79,27 @@ function geod_position_relative(line::geod_geodesicline, relative_arclength::Rea
     return geod_position(line, line.s13 * relative_arclength)
 end
 
+function geod_setdistance(l::geod_geodesicline, s13::Real)
+    geod_setdistance(pointer_from_objref(l), Cdouble(l13))
+end
+
+function geod_genposition(l::geod_geodesicline, flags::Union{Cuint, geod_flags}, s12_a12)
+    plat2 = Ref{Cdouble}(NaN64)
+    plon2 = Ref{Cdouble}(NaN64)
+    pazi2 = Ref{Cdouble}(NaN64)
+    ps12 = Ref{Cdouble}(NaN64)
+    pm12 = Ref{Cdouble}(NaN64)
+    pM12 = Ref{Cdouble}(NaN64)
+    pM21 = Ref{Cdouble}(NaN64)
+    pS12 = Ref{Cdouble}(NaN64)
+
+    geod_genposition(pointer_from_objref(l), flags, s12_a12, plat2, plon2, pazi2, ps12, pm12, pM12, pM21, pS12)
+
+    return (plat2[], plon2[], pazi2[], ps12[], pm12[], pM12[], pM21[], pS12[])
+
+end
+
+
 """
     geod_path(geodesic::geod_geodesic, lat1, lon1, lat2, lon2, npoints = 1000)
 

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -1,0 +1,72 @@
+
+# Constructors and null Constructors
+
+# geod_geodesic
+
+function _null(::Type{geod_geodesic})
+    return geod_geodesic(
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        ntuple(_ -> 0.0, Val(6)),
+        ntuple(_ -> 0.0, Val(15)),
+        ntuple(_ -> 0.0, Val(21)),
+    )
+end
+
+function geod_geodesic(equatorial_radius::Real, flattening::Real)
+    obj = _null(geod_geodesic)
+    geod_init(Ref(obj), Cdouble(equatorial_radius), Cdouble(flattening))
+    return obj
+end
+
+# geod_geodesicline
+
+function _null(::Type{Proj.geod_geodesicline})
+    return geod_geodesicline(
+        (0 for _ in 1:30)...,
+        ntuple(_ -> 0.0, 7), ntuple(_ -> 0.0, 7), ntuple(_ -> 0.0, 7), ntuple(_ -> 0.0, 6), ntuple(_ -> 0.0, 6),
+        Cuint(0)
+    )
+end
+
+
+function geod_directline(g::geod_geodesic, lat1, lon1, azi1, s12, caps::Cuint = UInt32(0))
+    obj = _null(geod_geodesicline)
+    geod_directline(
+        pointer_from_objref(obj),
+        pointer_from_objref(g), 
+        lat1, lon1, azi1, s12, caps
+    )
+    return obj
+end
+
+function geod_inverseline(g::geod_geodesic, lat1, lon1, lat2, lon2, caps::Cuint = UInt32(0))
+    obj = _null(geod_geodesicline)
+    geod_inverseline(
+        pointer_from_objref(obj),
+        pointer_from_objref(g), 
+        lat1, lon1, lat2, lon2, caps
+    )
+    return obj
+end
+
+# returns according to the C order (y, x, az).  Do we want this to return by the Julian order (x, y, azi)?  
+# If so, should this be a new function?
+function geod_position(line::geod_geodesicline, s12::Real)
+    lat = Ref{Cdouble}(NaN64)
+    lon = Ref{Cdouble}(NaN64)
+    azi = Ref{Cdouble}(NaN64)
+
+    return geod_position(pointer_from_objref(line), s12, lat, lon, azi)
+
+    return lat[], lon[], azi[]
+end
+
+"""
+    geod_position_relative(line::geod_geodesicline, relative_arclength::Real)
+
+Returns `(lat, lon, azimuth)` at the `relative_arclength` between the line's start and end point.  
+`relative_arclength` can be any real value, but values along the line should be between 0 and 1.
+"""
+function geod_position_relative(line::geod_geodesicline, relative_arclength::Real)
+    return geod_position(line, line.s13 * relative_arclength)
+end

--- a/src/geod.jl
+++ b/src/geod.jl
@@ -119,7 +119,7 @@ function geod_path(geodesic::geod_geodesic, lat1, lon1, lat2, lon2, npoints = 10
     lons = zeros(Float64, npoints)
 
     for i in 1:npoints
-        lats[i], lons[i], _ = geod_position_relative(inverse_line, (i-1)/npoints)
+        lats[i], lons[i], _ = geod_position_relative(inverse_line, (i-1)/(npoints-1))
     end
 
     return lats, lons

--- a/src/libproj.jl
+++ b/src/libproj.jl
@@ -2038,7 +2038,7 @@ The struct containing information about the ellipsoid. This must be initialized 
 | a     | the equatorial radius     |
 | f     | the flattening  ` SKIP `  |
 """
-mutable struct geod_geodesic
+struct geod_geodesic
     a::Cdouble
     f::Cdouble
     f1::Cdouble
@@ -2071,7 +2071,7 @@ The struct containing information about a single geodesic. This must be initiali
 | s13   | distance to reference point  ` SKIP `  |
 | caps  | the capabilities                       |
 """
-mutable struct geod_geodesicline
+struct geod_geodesicline
     lat1::Cdouble
     lon1::Cdouble
     azi1::Cdouble
@@ -2121,7 +2121,7 @@ The struct for accumulating information about a geodesic polygon. This is used f
 | lon   | the current longitude  ` SKIP `  |
 | num   | the number of points so far      |
 """
-mutable struct geod_polygon
+struct geod_polygon
     lat::Cdouble
     lon::Cdouble
     lat0::Cdouble

--- a/src/libproj.jl
+++ b/src/libproj.jl
@@ -2038,7 +2038,7 @@ The struct containing information about the ellipsoid. This must be initialized 
 | a     | the equatorial radius     |
 | f     | the flattening  ` SKIP `  |
 """
-struct geod_geodesic
+mutable struct geod_geodesic
     a::Cdouble
     f::Cdouble
     f1::Cdouble
@@ -2071,7 +2071,7 @@ The struct containing information about a single geodesic. This must be initiali
 | s13   | distance to reference point  ` SKIP `  |
 | caps  | the capabilities                       |
 """
-struct geod_geodesicline
+mutable struct geod_geodesicline
     lat1::Cdouble
     lon1::Cdouble
     azi1::Cdouble
@@ -2121,7 +2121,7 @@ The struct for accumulating information about a geodesic polygon. This is used f
 | lon   | the current longitude  ` SKIP `  |
 | num   | the number of points so far      |
 """
-struct geod_polygon
+mutable struct geod_polygon
     lat::Cdouble
     lon::Cdouble
     lat0::Cdouble

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -438,3 +438,36 @@ end
     # Maybe enable later, based on https://github.com/JuliaGeo/GeoFormatTypes.jl/issues/21
     # @test convert(GFT.ProjString, gftcrs) == GFT.ProjString("+proj=longlat +datum=WGS84 +no_defs +type=crs")
 end
+
+@testset "Geodesics" begin
+    
+    local geod, direct_line, inverse_line
+
+    # point 1 is JFK airport, point 2 is Changi airport
+    lat1, lon1, lat2, lon2 = 40.64, -73.78, 1.36, 103.99
+
+    @test_nowarn geod = Proj.geod_geodesic(6378137, 1/298.257223563)
+    @test_nowarn direct_line = Proj.geod_directline(geod, lat1, lon1, 3.3057734780176125, 1.534751294051294e7) # the azi1 and s13 values were computed directly
+    @test_nowarn inverse_line = Proj.geod_inverseline(geod, lat1, lon1, lat2, lon2)
+
+    @test begin
+        lat, lon = Proj.geod_position(direct_line, 0)
+        lat ≈ lat1 && lon ≈ lon1
+    end
+
+    @test begin
+        lat, lon = Proj.geod_position(inverse_line, 0)
+        lat ≈ lat1 && lon ≈ lon1
+    end
+
+    @test begin
+        lat, lon = Proj.geod_position_relative(direct_line, 1)
+        lat ≈ lat2 && lon ≈ lon2
+    end
+
+    @test begin
+        lat, lon = Proj.geod_position_relative(inverse_line, 1)
+        lat ≈ lat2 && lon ≈ lon2
+    end
+
+end

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -470,4 +470,9 @@ end
         lat ≈ lat2 && lon ≈ lon2
     end
 
+    @test begin
+        lats, lons = Proj.geod_path(geod, lat1, lon1, lat2, lon2, 2)
+        lats[1] ≈ lat1 && lats[2] ≈ lat2 && lons[1] ≈ lon1 && lons[2] ≈ lon2
+    end
+
 end

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -440,7 +440,7 @@ end
 end
 
 @testset "Geodesics" begin
-    
+
     local geod, direct_line, inverse_line
 
     # point 1 is JFK airport, point 2 is Changi airport

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -446,8 +446,9 @@ end
     # point 1 is JFK airport, point 2 is Changi airport
     lat1, lon1, lat2, lon2 = 40.64, -73.78, 1.36, 103.99
 
-    @test_nowarn geod = Proj.geod_geodesic(6378137, 1/298.257223563)
-    @test_nowarn direct_line = Proj.geod_directline(geod, lat1, lon1, 3.3057734780176125, 1.534751294051294e7) # the azi1 and s13 values were computed directly
+    @test_nowarn geod = Proj.geod_geodesic(6378137, 1 / 298.257223563)
+    @test_nowarn direct_line =
+        Proj.geod_directline(geod, lat1, lon1, 3.3057734780176125, 1.534751294051294e7) # the azi1 and s13 values were computed directly
     @test_nowarn inverse_line = Proj.geod_inverseline(geod, lat1, lon1, lat2, lon2)
 
     @test begin


### PR DESCRIPTION
This PR wraps the Proj `geod_*` API in a Julian API.  The idea is that the user should be able to pass objects directly instead of by passing pointers as you have to do now.  It also simplifies some constructors.

With the new API (example copied from the docs of `geod_position`),
```julia
# create a geodesic definition
geod = Proj.geod_geodesic(6378137, 1/298.257223563)
# create a line which solves the provided inverse problem
inv_line = Proj.geod_inverseline(geod, 40.64, -73.78, 1.36, 103.99)
# get positions as (lat, lon, az) which is how the C-API orders them
lats = zeros(Float64, 100)
lons = zeros(Float64, 100)

for (ind, relative_arclength) in enumerate(LinRange(0, 1, 100))
   lat, lon, _ = Proj.geod_position_relative(inv_line, relative_arclength)
   lats[ind] = lat
   lons[ind] = lon
end
```

![jfk_to_sin](https://user-images.githubusercontent.com/32143268/219867272-9cd5f9b9-aec3-4aba-8479-d3274b74b205.svg)

and the last part will be further simplified into a `geod_path` function.

Should I override the functions here, or create a new set of functions?  If so, how should we name them?