### PR TITLE
allow MixedFormat in CRS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Proj"
 uuid = "c94c279d-25a6-4763-9509-64d165bea63e"
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,6 +11,7 @@ NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 PROJ_jll = "58948b4f-47e0-5654-a9ad-f609743f8632"
 
 [compat]
+Aqua = "0.7"
 CEnum = "0.2, 0.3, 0.4"
 CoordinateTransformations = "0.6"
 GeoFormatTypes = "0.4"
@@ -19,8 +20,9 @@ PROJ_jll = "900.100, 901"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StaticArrays", "Test"]
+test = ["Aqua", "StaticArrays", "Test"]

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -29,8 +29,10 @@ function CRS(crs::AbstractString, ctx::Ptr{PJ_CONTEXT} = C_NULL)
     return CRS(crs)
 end
 
+const MaybeGFTCRS = Union{GFT.CRS,GFT.Unknown,GFT.Extended}
+
 function CRS(
-    crs::Union{GFT.CoordinateReferenceSystemFormat,GFT.MixedFormat},
+    crs::Union{GFT.CoordinateReferenceSystemFormat,GFT.MixedFormat{<:MaybeGFTCRS}},
     ctx::Ptr{PJ_CONTEXT} = C_NULL
 )
     crs = proj_create(convert(String, crs), ctx)
@@ -137,6 +139,8 @@ end
 
 Base.convert(T::Type{<:GFT.CoordinateReferenceSystemFormat}, crs::CRS) = T(crs)
 Base.convert(::Type{CRS}, crs::GFT.CoordinateReferenceSystemFormat) = CRS(crs)
+Base.convert(T::Type{<:GFT.MixedFormat}, crs::CRS) = T(crs)
+Base.convert(::Type{CRS}, crs::GFT.MixedFormat{<:MaybeGFTCRS}) = CRS(crs)
 
 # Maybe enable later, based on https://github.com/JuliaGeo/GeoFormatTypes.jl/issues/21
 # Base.convert(T::Type{<:GFT.CoordinateReferenceSystemFormat}, crs::GFT.CoordinateReferenceSystemFormat) = T(CRS(crs))

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -33,7 +33,7 @@ const MaybeGFTCRS = Union{GFT.CRS,GFT.Unknown,GFT.Extended}
 
 function CRS(
     crs::Union{GFT.CoordinateReferenceSystemFormat,GFT.MixedFormat{<:MaybeGFTCRS}},
-    ctx::Ptr{PJ_CONTEXT} = C_NULL
+    ctx::Ptr{PJ_CONTEXT} = C_NULL,
 )
     crs = proj_create(convert(String, crs), ctx)
     return CRS(crs)

--- a/src/crs.jl
+++ b/src/crs.jl
@@ -29,7 +29,10 @@ function CRS(crs::AbstractString, ctx::Ptr{PJ_CONTEXT} = C_NULL)
     return CRS(crs)
 end
 
-function CRS(crs::GFT.CoordinateReferenceSystemFormat, ctx::Ptr{PJ_CONTEXT} = C_NULL)
+function CRS(
+    crs::Union{GFT.CoordinateReferenceSystemFormat,GFT.MixedFormat},
+    ctx::Ptr{PJ_CONTEXT} = C_NULL
+)
     crs = proj_create(convert(String, crs), ctx)
     return CRS(crs)
 end

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -481,10 +481,10 @@ end
 
     # Check that we can round trip CRS/wkt without errors 
     @test GFT.EPSG(Proj.CRS(GFT.WellKnownText(crs))) ==
-          GFT.EPSG(Proj.CRS(GFT.WellKnownText2(crs))) 
+          GFT.EPSG(Proj.CRS(GFT.WellKnownText2(crs)))
 
     # This runs but we lose the EPSG number for testing
-    Proj.CRS(GFT.ESRIWellKnownText(crs)) 
+    Proj.CRS(GFT.ESRIWellKnownText(crs))
 end
 
 @testset "Geodesics" begin

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -472,6 +472,7 @@ end
     @test GFT.EPSG(crs) == GFT.EPSG("EPSG:4326")
 
     @test convert(GFT.EPSG, crs) == GFT.EPSG("EPSG:4326")
+    @test convert(GFT.WellKnownText2, crs) == GFT.WellKnownText2(crs)
     @test Proj.proj_get_id_code(convert(Proj.CRS, GFT.EPSG("EPSG:4326"))) ==
           Proj.proj_get_id_code(crs)
 

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -477,6 +477,13 @@ end
 
     # Maybe enable later, based on https://github.com/JuliaGeo/GeoFormatTypes.jl/issues/21
     # @test convert(GFT.ProjString, gftcrs) == GFT.ProjString("+proj=longlat +datum=WGS84 +no_defs +type=crs")
+
+    # Check that we can round trip CRS/wkt without errors 
+    @test GFT.EPSG(Proj.CRS(GFT.WellKnownText(crs))) ==
+          GFT.EPSG(Proj.CRS(GFT.WellKnownText2(crs))) 
+
+    # This runs but we lose the EPSG number for testing
+    Proj.CRS(GFT.ESRIWellKnownText(crs)) 
 end
 
 @testset "Geodesics" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Proj
 using Test
 using StaticArrays: SA
+import Aqua
 
 # Base.isapprox doesn't work on tuples
 is_approx(a, b) = all(isapprox(c[1], c[2]) for c in zip(a, b))
@@ -8,5 +9,5 @@ is_approx(a, b) = all(isapprox(c[1], c[2]) for c in zip(a, b))
 @testset "Proj" begin
     include("libproj.jl")
     include("applications.jl")
-
+    Aqua.test_all(Proj; ambiguities = false)
 end # testset "Proj"


### PR DESCRIPTION
Allow `convert` and `CRS(crs)` for `<: MixedFormat` objects other than `<: MixedFormat{<:Geom}`.

Closes #96 