### PR TITLE
Throw error for invalid transforms

### DIFF
--- a/src/coord.jl
+++ b/src/coord.jl
@@ -81,6 +81,7 @@ function Transformation(
     ctx::Ptr{PJ_CONTEXT} = C_NULL,
 )
     pj = proj_create_crs_to_crs(source_crs, target_crs, area, ctx)
+    pj === C_NULL && throw(ArgumentError("Cannot create the requested coordinate transformation."))
     pj = always_xy ? normalize_axis_order!(pj; ctx) : pj
     return Transformation(pj, direction)
 end
@@ -115,6 +116,7 @@ function Transformation(
         Pass either one pipeline or a source and target CRS.
         CRS given: $(repr(pipeline))"""))
     end
+    pj === C_NULL && throw(ArgumentError("Cannot create the requested coordinate transformation."))
     pj = always_xy ? normalize_axis_order!(pj; ctx) : pj
     return Transformation(pj, direction)
 end
@@ -128,6 +130,7 @@ function Transformation(
     ctx::Ptr{PJ_CONTEXT} = C_NULL,
 )
     pj = proj_create_crs_to_crs_from_pj(source_crs, target_crs, area, ctx)
+    pj === C_NULL && throw(ArgumentError("Cannot create the requested coordinate transformation."))
     pj = always_xy ? normalize_axis_order!(pj; ctx) : pj
     return Transformation(pj, direction)
 end

--- a/test/libproj.jl
+++ b/test/libproj.jl
@@ -173,6 +173,13 @@ end
         "+proj=pipeline +ellps=GRS80 +step +proj=merc +step +proj=axisswap +order=2,1",
     )
 
+    # Transformation errors when attempting a transform from an engineering crs
+    crs_string = "LOCAL_CS[\"unnamed\",UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
+    crs = GFT.WellKnownText(GFT.CRS(), crs_string)
+    @test_throws ArgumentError Proj.Transformation(crs_string, "EPSG:4326")
+    @test_throws ArgumentError Proj.Transformation(crs, GFT.EPSG(4326))
+    @test_throws ArgumentError Proj.Transformation(crs_string, "EPSG:4326", always_xy = true)
+    @test_throws ArgumentError Proj.Transformation(crs, GFT.EPSG(4326), always_xy = true)
 end
 
 @testset "single transformation" begin


### PR DESCRIPTION
Partially resolves https://github.com/JuliaGeo/Proj.jl/issues/114

Maybe there is more work to do here with crstrait and what not, but we can all agree that segfaulting is bad and throwing more informative errors is good. So this PR just checks if the pointer that comes out of the proj call is `C_NULL` and throws an error if it is, rather than returning a Transformation with a null pointer (or segfaulting immediately if always_xy is true).

It should be possible to print the requested CRS's in the error message, but I'm not sure how since we only have the pointer and not the `CRS` object.