### PR TITLE
Run CI on pre releases instead of nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,8 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        arch:
+          - default
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,13 +20,11 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
           - 'pre'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Proj"
 uuid = "c94c279d-25a6-4763-9509-64d165bea63e"
-version = "1.8.1"
+version = "1.9.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -20,7 +20,7 @@ NetworkOptions = "1"
 PROJ_jll = "902.500"
 StaticArrays = "1"
 Test = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
Currently our CI badge on the readme is always red due to failing tests on nightly, and in https://github.com/JuliaGeo/Proj.jl/actions/runs/14427702016 I also see this warning:

> x64 arch has been requested on a macOS runner that has an arm64 (Apple Silicon) architecture. You may have meant to use the "aarch64" arch instead (or left it unspecified for the correct default).

So this removes the architecture, and uses 1.12-beta1 rather than the master branch.