### PR TITLE
Fix CLI test converting points to strings

### DIFF
--- a/test/applications.jl
+++ b/test/applications.jl
@@ -30,7 +30,7 @@ end == "111d0'3.006\"W 50d0'0.125\"N 0.000"
 
 function xyzt_transform_cli(point::AbstractVector; network::Bool = false)
     # convert the vector to a string like "-33 151 5 2020"
-    input = String(strip(string(point'), ('[', ']')))
+    input = join(point, ' ')
     xyzt_transform_cli(input; network)
 end
 


### PR DESCRIPTION
Fixes #117, failing tests on Julia 1.12+.

It was just a test function that converted points to strings in a bit of a hacky way that broke since adjoints of StaticArrays are now apparently printed as `adjoint([-33, 151, 5])`.